### PR TITLE
Migration from C2DM to GCM

### DIFF
--- a/android/src/main/java/org/tiqr/authenticator/C2DMReceiver.java
+++ b/android/src/main/java/org/tiqr/authenticator/C2DMReceiver.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
  */
 public class C2DMReceiver extends C2DMBaseReceiver
 {
-    public static final String SENDER_ID = "aai-beheer@surfnet.nl";
+    public static final String SENDER_ID = "70645846943";
 
     protected @Inject NotificationService _notificationService;
 


### PR DESCRIPTION
* Switched the sender ID from the C2DM one to the new GCM one.
* Added a version number for the GCM API. If this changes, the old device token will be treated as not existing. This forces the app to request a new token for GCM.

--------
TokenExchange transition: Since the `notificationToken` property is stored separataly, it will automatically update the device token on the server if there's an existing notification token. Otherwise a new one will be created.