### PR TITLE
TIQR-80: Fixed identify info screen to show user details when using nl or fy language

### DIFF
--- a/android/src/main/res/values-fy/strings.xml
+++ b/android/src/main/res/values-fy/strings.xml
@@ -5,8 +5,7 @@
   <string name="authentication_title">Ynloche</string>
   <string name="identity_title">Identiteiten</string>
   <string name="identity_blocked">Blokkearre</string>
-  <string name="identity_blocked_message">Warskôging: dit akkount is blokkeart
-en moat op ‘e nij aktiveart wurde.</string>
+  <string name="identity_blocked_message">Warskôging: dit akkount is blokkeart\nen moat op ‘e nij aktiveart wurde.</string>
   <string name="confirm_enrollment_title">Registraasje befêstigje</string>
   <string name="confirm_authentication_title">Ynloch befêstigje </string>
   <string name="select_identity_title">Selektear identiteit</string>

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -5,8 +5,7 @@
   <string name="authentication_title">Login</string>
   <string name="identity_title">Identiteiten</string>
   <string name="identity_blocked">Geblokkeerd</string>
-  <string name="identity_blocked_message">Waarschuwing: dit account is geblokkeerd
-en moet opnieuw geactiveerd worden.</string>
+  <string name="identity_blocked_message">Waarschuwing: dit account is geblokkeerd\nen moet opnieuw geactiveerd worden.</string>
   <string name="confirm_enrollment_title">Registratie bevestigen</string>
   <string name="confirm_authentication_title">Login bevestigen</string>
   <string name="select_identity_title">Selecteer identiteit</string>


### PR DESCRIPTION
Translation files didn't include the \n instead had a newspace in the translation file which wasn't picked up. 

After checking all the translations files (issue was reported to be on dutch only) I found the same newline on the fy language file and updated it. Other files were already using the \n newline character.