### PR TITLE
Two crash fixes and disable of autofill on PIN input

### DIFF
--- a/android/src/main/java/org/tiqr/authenticator/general/AbstractAuthenticationActivity.java
+++ b/android/src/main/java/org/tiqr/authenticator/general/AbstractAuthenticationActivity.java
@@ -1,7 +1,11 @@
 package org.tiqr.authenticator.general;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ProgressDialog;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
 
 import org.tiqr.authenticator.auth.Challenge;
 
@@ -14,6 +18,17 @@ public abstract class AbstractAuthenticationActivity extends Activity {
 
     private ProgressDialog _progressDialog;
 
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        disableAutoFill();
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private void disableAutoFill() {
+        getWindow().getDecorView().setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS);
+    }
 
     /**
      * Returns the challenge.

--- a/android/src/main/java/org/tiqr/authenticator/identity/IdentityDetailActivity.java
+++ b/android/src/main/java/org/tiqr/authenticator/identity/IdentityDetailActivity.java
@@ -1,6 +1,7 @@
 package org.tiqr.authenticator.identity;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
@@ -18,6 +19,7 @@ import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.Switch;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.tiqr.authenticator.Application;
 import org.tiqr.authenticator.MainActivity;
@@ -112,7 +114,11 @@ public class IdentityDetailActivity extends Activity {
                 @Override
                 public void onClick(View v) {
                     Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(infoUrl));
-                    startActivity(browserIntent);
+                    try {
+                        startActivity(browserIntent);
+                    } catch (ActivityNotFoundException ex) {
+                        Toast.makeText(v.getContext(), R.string.error_browser_not_available, Toast.LENGTH_LONG).show();
+                    }
                 }
             });
 

--- a/android/src/main/res/values-nl/strings.xml
+++ b/android/src/main/res/values-nl/strings.xml
@@ -132,6 +132,7 @@ eenmalige gegevens in te geven:</string>
   <string name="error_enroll_failed_to_store_identity">Opslaan identeit mislukt. Neem contact op met support.</string>
   <string name="error_enroll_failed_to_generate_secret">Genereren geheim mislukt. Neem contact op met support.</string>
   <string name="error_device_incompatible_with_security_standards">Telefoon is niet compatible met de vereiste beveiligingsstandaarden.</string>
+  <string name="error_browser_not_available">Geen browser beschikbaar voor het openen van deze URL.</string>
   <string name="provided_by">aangeboden door:</string>
   <string name="main_text_welcome">Met tiqr kunt u met uw smartphone veilig en vertrouwd inloggen bij 
 verschillende webdiensten. &lt;br/&gt;

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -166,4 +166,5 @@ reactivating your account. Press <b>Scan</b> if asked.</string>
     <string name="identity_uses_fingerprint">Uses fingerprint</string>
     <string name="identity_upgrade_to_fingerprint">Upgrade to fingerprint after next login</string>
     <string name="error_show_technical_details">Show technical details</string>
+    <string name="error_browser_not_available">A browser needs to be installed to open this URL.</string>
 </resources>

--- a/shared/src/main/java/org/tiqr/authenticator/security/Secret.java
+++ b/shared/src/main/java/org/tiqr/authenticator/security/Secret.java
@@ -11,6 +11,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableEntryException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
 import javax.crypto.SecretKey;
@@ -59,7 +60,8 @@ public class Secret {
         }
     }
 
-    private SecretKey _loadFromKeyStore(SecretKey sessionKey, Type type) throws SecurityFeaturesException, InvalidKeyException, CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, UnrecoverableEntryException {
+    private SecretKey _loadFromKeyStore(SecretKey sessionKey, Type type) throws SecurityFeaturesException, InvalidKeyException, CertificateException,
+            NoSuchAlgorithmException, KeyStoreException, IOException, UnrecoverableEntryException {
         SecretKey deviceKey = Encryption.getDeviceKey(_ctx);
         CipherPayload civ = _store.getSecretKey(getId(type), deviceKey);
         if (civ == null || civ.cipherText == null) {

--- a/shared/src/main/java/org/tiqr/authenticator/security/SecretStore.java
+++ b/shared/src/main/java/org/tiqr/authenticator/security/SecretStore.java
@@ -87,7 +87,8 @@ public class SecretStore {
         }
     }
 
-    public CipherPayload getSecretKey(String identity, SecretKey sessionKey) throws UnrecoverableEntryException, NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
+    public CipherPayload getSecretKey(String identity, SecretKey sessionKey) throws UnrecoverableEntryException,
+            NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
         _initializeKeyStore(sessionKey);
         SecretKeyEntry ctEntry;
         SecretKeyEntry ivEntry;
@@ -112,6 +113,9 @@ public class SecretStore {
         } else {
             ivBytes = ivEntry.getSecretKey().getEncoded();
             Log.i("encryption", "IV for: " + identity + " is " + new String(Base64Coder.encode(ivBytes)));
+        }
+        if (ctEntry == null || ctEntry.getSecretKey() == null) {
+            throw new UnrecoverableKeyException("Cipher entry has not been found!");
         }
         CipherPayload cipherPayload = new CipherPayload(ctEntry.getSecretKey().getEncoded(), ivBytes);
         if (migrateKeys) {


### PR DESCRIPTION
Disabling autofill was required because LastPass tried to fill the pin, which was not working properly.