### PR TITLE
Validate existing tokens & better handling of responses for token requests

### DIFF
--- a/android/src/main/java/org/tiqr/authenticator/TiqrApplication.kt
+++ b/android/src/main/java/org/tiqr/authenticator/TiqrApplication.kt
@@ -27,9 +27,11 @@ class TiqrApplication : android.app.Application() {
                 .also {
                     it.inject(this)
                 }
+
+
         val token = FirebaseInstanceId.getInstance().token
         if (token != null && !TextUtils.isEmpty(token)) {
-            notificationService.sendRequestWithDeviceToken(token)
+            notificationService.requestNewToken(token)
         }
     }
 

--- a/android/src/main/java/org/tiqr/authenticator/messaging/TiqrFirebaseMessagingService.java
+++ b/android/src/main/java/org/tiqr/authenticator/messaging/TiqrFirebaseMessagingService.java
@@ -73,7 +73,7 @@ public class TiqrFirebaseMessagingService extends FirebaseMessagingService {
     public void onNewToken(String token) {
         super.onNewToken(token);
         Log.d(TAG, "Refreshed token: " + token);
-        _notificationService.sendRequestWithDeviceToken(token);
+        _notificationService.requestNewToken(token);
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.5.2.0"
 
     }
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: "de.mannodermaus.android-junit5"
 
 android {
     compileSdkVersion 28
@@ -17,8 +18,11 @@ android {
     androidExtensions {
         experimental = true
     }
+    testOptions{
+        unitTests.returnDefaultValues = true
+    }
 }
-    
+
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -33,6 +37,13 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     implementation "androidx.core:core-ktx:1.0.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
+
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0'
+    testImplementation 'org.assertj:assertj-core:3.9.0'
 }
 repositories {
     mavenCentral()

--- a/shared/src/main/java/org/tiqr/service/Token.kt
+++ b/shared/src/main/java/org/tiqr/service/Token.kt
@@ -1,0 +1,6 @@
+package org.tiqr.service
+
+sealed class Token {
+    data class Valid(val value: String) : Token()
+    object Invalid : Token()
+}

--- a/shared/src/test/java/org/tiqr/UtilsTest.kt
+++ b/shared/src/test/java/org/tiqr/UtilsTest.kt
@@ -1,0 +1,61 @@
+package org.tiqr
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.tiqr.service.Token
+
+internal class UtilsUnitTest {
+
+    private val testableConnection = Mockito.mock(TestableConnectionWrapper::class.java)
+
+    @Test
+    internal fun `when the response code is not in the 200 range then the token is invalid`() {
+        whenever(testableConnection.responseCode).thenReturn(HTTP_FAIL)
+
+        val newToken = Utils.testableReadResponse(testableConnection)
+
+        assertThat(newToken).isEqualTo(Token.Invalid)
+    }
+
+    @Test
+    internal fun `when the response code is in the 200 range and the response is other than NOT FOUND, then the token is valid`() {
+        whenever(testableConnection.responseCode).thenReturn(HTTP_OK)
+        whenever(testableConnection.readResponse()).thenReturn(VALID_TOKEN)
+
+        val newToken = Utils.testableReadResponse(testableConnection)
+
+        assertThat(newToken).isEqualTo(Token.Valid(VALID_TOKEN))
+    }
+
+    @Test
+    internal fun `when the response code is in the 200 range and the response is NOT FOUND, then the token is invalid`() {
+        whenever(testableConnection.responseCode).thenReturn(HTTP_OK)
+        whenever(testableConnection.readResponse()).thenReturn(INVALID_TOKEN)
+
+        val newToken = Utils.testableReadResponse(testableConnection)
+
+        assertThat(newToken).isEqualTo(Token.Invalid)
+    }
+
+    @Test
+    internal fun `when the response code is in the 200 range but reading the response throws an error, then the token is invalid`() {
+        whenever(testableConnection.responseCode).thenReturn(HTTP_OK)
+        whenever(testableConnection.readResponse()).thenThrow(Exception())
+
+        val newToken = Utils.testableReadResponse(testableConnection)
+
+        assertThat(newToken).isEqualTo(Token.Invalid)
+    }
+
+
+    companion object {
+        const val VALID_TOKEN = "valid"
+        const val INVALID_TOKEN = "NOT FOUND"
+
+        const val HTTP_OK = 200
+        const val HTTP_FAIL = 500
+    }
+
+}

--- a/shared/src/test/java/org/tiqr/service/notification/NotificationServiceTest.kt
+++ b/shared/src/test/java/org/tiqr/service/notification/NotificationServiceTest.kt
@@ -1,0 +1,86 @@
+package org.tiqr.service.notification
+
+import android.content.Context
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.tiqr.service.Token
+
+internal class NotificationServiceTest {
+
+    private val context = mock(Context::class.java)
+
+    @Test
+    fun `when an existing token is corrupt, it should be removed`() {
+        val service = NotificationServiceSUT("existing token is corrupted", true, Token.Invalid, context)
+
+        service.validateExistingToken()
+
+        assertThat(service.performedSave).isEqualTo(NewToken.IsCleared)
+    }
+
+    @Test
+    internal fun `when we have a valid token, it should be part of the post data`() {
+        val service = NotificationServiceSUT(VALID_TOKEN, true, Token.Valid(VALID_TOKEN), context)
+
+        val postData = service.createPostData(DEVICE_TOKEN)
+
+        assertThat(postData.keys.size).isEqualTo(2)
+    }
+
+    @Test
+    internal fun `when we have a valid token, it's value should be in the post data`() {
+        val service = NotificationServiceSUT(VALID_TOKEN, true, Token.Valid(VALID_TOKEN), context)
+
+        val postData = service.createPostData(DEVICE_TOKEN)
+
+        assertThat(postData["notificationToken"]).isEqualTo(VALID_TOKEN)
+    }
+
+    @Test
+    internal fun `for a given device token, it's value should be in the post data`() {
+        val service = NotificationServiceSUT(VALID_TOKEN, true, Token.Valid(VALID_TOKEN), context)
+
+        val postData = service.createPostData(DEVICE_TOKEN)
+
+        assertThat(postData["deviceToken"]).isEqualTo(DEVICE_TOKEN)
+    }
+
+    @Test
+    internal fun `when a new valid token is received it should be saved`() {
+        val service = NotificationServiceSUT(null, true, Token.Valid(VALID_TOKEN), context)
+
+        service.testableRequestNewToken(DEVICE_TOKEN)
+
+        assertThat(service.performedSave).isEqualTo(NewToken.HasValue(VALID_TOKEN))
+    }
+
+    companion object {
+        const val VALID_TOKEN = " This. Be. VALID. "
+        const val DEVICE_TOKEN = "DeviceToken"
+    }
+
+    class NotificationServiceSUT(existingToken: String?, shouldValidate: Boolean, private val newToken: Token, context: Context) : NotificationService(context) {
+        var performedSave: NewToken? = null
+
+        override val notificationToken = existingToken
+        override var shouldValidateExistingToken = shouldValidate
+
+        override fun requestToken(nameValuePairs: HashMap<String, String>): Token = newToken
+
+        override fun saveNewToken(notificationToken: String?) {
+            //We don't want this to go to shared preferences, it adds no value
+            performedSave = if (notificationToken == null) {
+                NewToken.IsCleared
+            } else {
+                NewToken.HasValue(notificationToken)
+            }
+        }
+
+    }
+
+    sealed class NewToken {
+        data class HasValue(val value: String) : NewToken()
+        object IsCleared : NewToken()
+    }
+}


### PR DESCRIPTION
Fixes #83 

After requesting a new token at startup, when parsing the response, the response codes that are outside of the 200 range result in an invalid token which will not be saved.
Given the fact that
1 - whenever a request for a new token is made, the post data includes the existing token
2 - the api returns the existing token without verification
3 - existing tokens might have been corrupted, therefore the invalid value is perpetuated ad infinitum after a single failure
Then the existing token is validated once and only once, prior to sending it as part of the post data.
If the validation fails, the existing token is cleared. (set to null)